### PR TITLE
Add GPS tracker model to device info

### DIFF
--- a/custom_components/pitpat/const.py
+++ b/custom_components/pitpat/const.py
@@ -1,3 +1,6 @@
+from typing import Dict
+
+
 DOMAIN = "pitpat"
 MANUFACTURER = "PitPat"
 
@@ -6,3 +9,7 @@ OPTIONS_KEY_UPDATE_INTERVAL = "update_interval"
 DATA_KEY_COORDINATOR = "coordinator"
 
 UPDATE_INTERVAL_DEFAULT = 5
+
+DEVICE_MODEL_MAP: Dict[int, str] = {
+    6: 'GPS Tracker'
+}

--- a/custom_components/pitpat/device_tracker.py
+++ b/custom_components/pitpat/device_tracker.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 import logging
 from typing import Any, Dict
 
@@ -7,11 +6,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_IDENTIFIERS,
-    ATTR_NAME,
-    ATTR_MANUFACTURER,
-    ATTR_SW_VERSION,
-    ATTR_HW_VERSION,
-    ATTR_SERIAL_NUMBER,
 )
 from homeassistant.components.device_tracker.config_entry import (
     TrackerEntity,
@@ -22,7 +16,6 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import (
     DATA_KEY_COORDINATOR,
     DOMAIN,
-    MANUFACTURER,
 )
 from .coordinator import PitPatDataUpdateCoordinator
 
@@ -100,10 +93,5 @@ class PitPatDogDeviceTrackerEntity(CoordinatorEntity[PitPatDataUpdateCoordinator
     def device_info(self):
         """Return device information about this device."""
         return {
-            ATTR_IDENTIFIERS: {(DOMAIN, self._dog_id)},
-            ATTR_NAME: self.data.get('Name'),
-            ATTR_MANUFACTURER: MANUFACTURER,
-            ATTR_SW_VERSION: self.data.get("Monitor", {}).get("FirmwareVersion", ""),
-            ATTR_HW_VERSION: self.data.get("Monitor", {}).get("HardwareVersion", ""),
-            ATTR_SERIAL_NUMBER: _get_monitor(self.data).get('SerialNumber')
+            ATTR_IDENTIFIERS: {(DOMAIN, self._dog_id)}
         }

--- a/custom_components/pitpat/sensor.py
+++ b/custom_components/pitpat/sensor.py
@@ -6,6 +6,8 @@ import dateutil
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
+    ATTR_MODEL,
+    ATTR_MODEL_ID,
     EntityCategory,
     UnitOfEnergy,
     UnitOfLength,
@@ -29,6 +31,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
     DATA_KEY_COORDINATOR,
+    DEVICE_MODEL_MAP,
     DOMAIN,
     MANUFACTURER,
 )
@@ -316,6 +319,8 @@ class PitPatDogSensorEntity(CoordinatorEntity[PitPatDataUpdateCoordinator], Sens
             ATTR_IDENTIFIERS: {(DOMAIN, self._dog_id)},
             ATTR_NAME: self.data.get('Name'),
             ATTR_MANUFACTURER: MANUFACTURER,
+            ATTR_MODEL_ID: self.data.get('Monitor', {}).get('Model'),
+            ATTR_MODEL: DEVICE_MODEL_MAP.get(int(self.data.get('Monitor', {}).get('Model')), ''),
             ATTR_SW_VERSION: self.data.get("Monitor", {}).get("FirmwareVersion", ""),
             ATTR_HW_VERSION: self.data.get("Monitor", {}).get("HardwareVersion", ""),
             ATTR_SERIAL_NUMBER: _get_monitor(self.data).get('SerialNumber')


### PR DESCRIPTION
<!-- Note for Deosrc: Remember to update the manifest.json version number!  -->

Mostly to allow adding to the [Battery Notes](https://github.com/andrew-codechimp/HA-Battery-Notes) library.

Only supports GPS Tracker. Other model numbers are unknown.